### PR TITLE
Fix social icons and place labels below icons

### DIFF
--- a/docs/specs/social-links.md
+++ b/docs/specs/social-links.md
@@ -1,0 +1,19 @@
+# Social links layout spec
+
+## Purpose and scope
+Ensure the hero social links display correctly by rendering the email, LinkedIn, and GitHub/portfolio icons with their labels placed beneath each icon in the hero section.
+
+## Inputs and outputs
+- **Inputs:**
+  - `index.html` hero markup for `.social-links`.
+  - `style.css` styling for `.social-links` elements.
+- **Outputs:**
+  - Updated HTML/CSS so each social link shows an icon with its label directly below.
+
+## Success criteria and acceptance tests
+- Each social link inside `.social-links` contains an icon element followed by a label element in the markup.
+- The CSS for `.social-links a` uses a vertical layout (`flex-direction: column`).
+- The label is visually placed below the icon (e.g., by using block-level layout for the label).
+
+## Edge cases and error-handling rules
+- If additional social links are added later, the structure and layout rules should still place labels below icons without further changes.

--- a/style.css
+++ b/style.css
@@ -119,6 +119,7 @@ a:hover {
   flex-direction: column;
   align-items: center;
   gap: 0.35rem;
+  text-align: center;
   color: var(--accent);
   transition: all 0.3s ease;
 }
@@ -146,6 +147,7 @@ a:hover {
 }
 
 .social-links .social-label {
+  display: block;
   font-size: 0.65rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -156,6 +158,7 @@ a:hover {
 
 /* SVG icon sizing within social links */
 .social-links svg.icon {
+  display: block;
   width: 1.2rem;
   height: 1.2rem;
 }

--- a/tests/test_social_links.py
+++ b/tests/test_social_links.py
@@ -1,0 +1,108 @@
+"""Tests for hero social link layout and structure."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+from html.parser import HTMLParser
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[1]
+INDEX_PATH = ROOT_DIR / "index.html"
+STYLE_PATH = ROOT_DIR / "style.css"
+
+
+class SocialLinksParser(HTMLParser):
+    """Capture social link children to validate icon/label order."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._in_social_links = False
+        self._social_links_div_depth = 0
+        self._current_anchor_spans: list[str] = []
+        self.anchor_spans: list[list[str]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attrs_dict = dict(attrs)
+        classes = set((attrs_dict.get("class") or "").split())
+
+        if tag == "div" and "social-links" in classes:
+            self._in_social_links = True
+            self._social_links_div_depth = 1
+            return
+
+        if self._in_social_links and tag == "div":
+            self._social_links_div_depth += 1
+
+        if not self._in_social_links:
+            return
+
+        if tag == "a":
+            self._current_anchor_spans = []
+            return
+
+        if tag == "span" and "class" in attrs_dict:
+            span_class = attrs_dict.get("class") or ""
+            if "social-icon" in span_class:
+                self._current_anchor_spans.append("social-icon")
+            if "social-label" in span_class:
+                self._current_anchor_spans.append("social-label")
+
+    def handle_endtag(self, tag: str) -> None:
+        if not self._in_social_links:
+            return
+
+        if tag == "a" and self._current_anchor_spans:
+            self.anchor_spans.append(self._current_anchor_spans)
+            self._current_anchor_spans = []
+            return
+
+        if tag == "div":
+            self._social_links_div_depth -= 1
+            if self._social_links_div_depth <= 0:
+                self._in_social_links = False
+                self._social_links_div_depth = 0
+
+
+class TestSocialLinks(unittest.TestCase):
+    """Validate social link icon/label structure and layout rules."""
+
+    def test_social_links_icon_and_label_order(self) -> None:
+        """Each social link should list icon before label to stack correctly."""
+        content = INDEX_PATH.read_text(encoding="utf-8")
+        parser = SocialLinksParser()
+        parser.feed(content)
+
+        self.assertGreaterEqual(len(parser.anchor_spans), 3)
+        for spans in parser.anchor_spans:
+            self.assertIn("social-icon", spans)
+            self.assertIn("social-label", spans)
+            self.assertLess(
+                spans.index("social-icon"),
+                spans.index("social-label"),
+                "Icon should appear before label in each link.",
+            )
+
+    def test_social_links_css_uses_column_layout(self) -> None:
+        """Social links should stack icon over label using column flex layout."""
+        css = STYLE_PATH.read_text(encoding="utf-8")
+        link_block = re.search(
+            r"\.social-links\s+a\s*\{[^}]*\}", css, re.DOTALL
+        )
+        self.assertIsNotNone(link_block)
+        self.assertRegex(link_block.group(0), r"flex-direction\s*:\s*column")
+
+    def test_social_label_is_block_level(self) -> None:
+        """Labels should be block-level so they render below icons."""
+        css = STYLE_PATH.read_text(encoding="utf-8")
+        label_block = re.search(
+            r"\.social-links\s+\.social-label\s*\{[^}]*\}",
+            css,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(label_block)
+        self.assertRegex(label_block.group(0), r"display\s*:\s*block")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Ensure the hero social links (email, LinkedIn, GitHub/portfolio) show their labels beneath the circular icons and align consistently across viewports.
- Add a small specification and automated checks so future changes don't regress the icon/label layout.

### Description
- Update `style.css` to center link content and force label and SVG to behave as block-level elements by adding `text-align: center` to `.social-links a`, `display: block` to `.social-links .social-label`, and `display: block` to `.social-links svg.icon` so labels render below icons.
- Add `docs/specs/social-links.md` with a concise layout spec, inputs/outputs, acceptance criteria, and edge-case notes.
- Add `tests/test_social_links.py` which parses `index.html` and asserts each link contains a `social-icon` before a `social-label` and validates CSS contains `flex-direction: column` and `display: block` for the label.

### Testing
- Ran the test suite with `python -m unittest discover -s tests` which executed 3 tests and all tests passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b14616608832599fd009b34c91925)