### PR TITLE
Add copyable contact section to CV site

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,6 +226,71 @@
         </ul>
       </div>
     </section>
+    <!-- Contacts section with copy-friendly fields -->
+    <section id="contacts" class="section dark" data-aos="fade-up">
+      <div class="container">
+        <h3>Contact</h3>
+        <p>
+          Reach out directly using the fields below. Each value is formatted for
+          quick copy and paste into your preferred email or messaging tool.
+        </p>
+        <div class="contact-grid">
+          <div class="contact-card">
+            <span class="contact-label">Email</span>
+            <div class="contact-copy">
+              <input
+                id="contact-email"
+                type="text"
+                readonly
+                value="jethrop192168@gmail.com"
+                aria-label="Email address"
+              />
+              <button class="copy-btn" type="button" data-copy-target="contact-email">
+                Copy
+              </button>
+            </div>
+          </div>
+          <div class="contact-card">
+            <span class="contact-label">LinkedIn</span>
+            <div class="contact-copy">
+              <input
+                id="contact-linkedin"
+                type="text"
+                readonly
+                value="https://www.linkedin.com/in/jethro-pesquera/"
+                aria-label="LinkedIn profile URL"
+              />
+              <button
+                class="copy-btn"
+                type="button"
+                data-copy-target="contact-linkedin"
+              >
+                Copy
+              </button>
+            </div>
+          </div>
+          <div class="contact-card">
+            <span class="contact-label">Portfolio</span>
+            <div class="contact-copy">
+              <input
+                id="contact-portfolio"
+                type="text"
+                readonly
+                value="https://jethrop.github.io/"
+                aria-label="Portfolio URL"
+              />
+              <button
+                class="copy-btn"
+                type="button"
+                data-copy-target="contact-portfolio"
+              >
+                Copy
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
     <!-- Footer -->
     <footer class="footer">
       <div class="container">

--- a/script.js
+++ b/script.js
@@ -7,6 +7,52 @@ function initAos() {
   });
 }
 
+/**
+ * Enable one-click copy for contact fields with a graceful fallback.
+ * Uses the Clipboard API when available, then falls back to selection copy.
+ */
+function initCopyButtons() {
+  const buttons = document.querySelectorAll('[data-copy-target]');
+  if (!buttons.length) return;
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', async () => {
+      const targetId = button.getAttribute('data-copy-target');
+      const input = targetId ? document.getElementById(targetId) : null;
+      if (!input) return;
+
+      const valueToCopy = input.value;
+      let copied = false;
+
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+        try {
+          await navigator.clipboard.writeText(valueToCopy);
+          copied = true;
+        } catch (error) {
+          copied = false;
+        }
+      }
+
+      if (!copied) {
+        input.focus();
+        input.select();
+        copied = document.execCommand('copy');
+        input.setSelectionRange(0, 0);
+      }
+
+      if (copied) {
+        const originalLabel = button.textContent;
+        button.textContent = 'Copied!';
+        button.classList.add('copied');
+        setTimeout(() => {
+          button.textContent = originalLabel;
+          button.classList.remove('copied');
+        }, 2000);
+      }
+    });
+  });
+}
+
 // Typing effect for the hero subheading
 const typingElement = document.getElementById('typing');
 const phrases = [
@@ -44,6 +90,7 @@ function typeLoop() {
 // Start typing effect after DOM has loaded
 document.addEventListener('DOMContentLoaded', () => {
   initAos();
+  initCopyButtons();
 
   if (typingElement) {
     typeLoop();

--- a/style.css
+++ b/style.css
@@ -362,6 +362,73 @@ a:hover {
   font-size: 0.9rem;
 }
 
+/* Contacts */
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.contact-card {
+  background-color: var(--card-bg-dark);
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+.contact-label {
+  display: block;
+  font-weight: 600;
+  color: var(--accent);
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.03em;
+}
+
+.contact-copy {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.contact-copy input {
+  flex: 1 1 220px;
+  padding: 0.65rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background-color: rgba(8, 18, 35, 0.7);
+  color: var(--text-light);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+}
+
+.contact-copy input:focus {
+  outline: 2px solid rgba(0, 191, 166, 0.6);
+  outline-offset: 2px;
+}
+
+.copy-btn {
+  border: none;
+  border-radius: 6px;
+  padding: 0.6rem 1.2rem;
+  background-color: var(--accent);
+  color: var(--bg-dark);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.copy-btn:hover,
+.copy-btn:focus-visible {
+  background-color: #38fbd7;
+  transform: translateY(-2px);
+}
+
+.copy-btn.copied {
+  background-color: #1fb86b;
+}
+
 /* Footer */
 .footer {
   background-color: var(--bg-dark);

--- a/tests/test_contact_section.py
+++ b/tests/test_contact_section.py
@@ -1,0 +1,109 @@
+"""Specification tests for the copy-friendly contact section.
+
+Purpose and scope:
+- Ensure the CV includes a dedicated contact section with copy-friendly fields.
+
+Inputs and outputs:
+- Inputs: index.html and style.css.
+- Output: tests validate expected HTML structure and CSS rules.
+
+Success criteria / acceptance tests:
+- A section with id="contacts" exists and includes a contact grid.
+- Each contact method renders a readonly input paired with a copy button.
+- Contact grid uses CSS grid and the copy button uses a pointer cursor.
+
+Edge cases and error-handling:
+- Missing IDs or non-readonly inputs should fail fast.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+from html.parser import HTMLParser
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[1]
+INDEX_PATH = ROOT_DIR / "index.html"
+STYLE_PATH = ROOT_DIR / "style.css"
+
+
+class ContactSectionParser(HTMLParser):
+    """Parse the contact section to capture inputs and copy buttons."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._in_contacts_section = False
+        self._contacts_section_depth = 0
+        self.has_contact_grid = False
+        self.copy_buttons: list[str] = []
+        self.readonly_inputs: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attrs_dict = dict(attrs)
+        classes = set((attrs_dict.get("class") or "").split())
+
+        if tag == "section" and attrs_dict.get("id") == "contacts":
+            self._in_contacts_section = True
+            self._contacts_section_depth = 1
+            return
+
+        if self._in_contacts_section and tag == "section":
+            self._contacts_section_depth += 1
+
+        if not self._in_contacts_section:
+            return
+
+        if tag == "div" and "contact-grid" in classes:
+            self.has_contact_grid = True
+
+        if tag == "input" and "readonly" in attrs_dict:
+            input_id = attrs_dict.get("id")
+            if input_id:
+                self.readonly_inputs.append(input_id)
+
+        if tag == "button" and attrs_dict.get("data-copy-target"):
+            self.copy_buttons.append(attrs_dict["data-copy-target"])
+
+    def handle_endtag(self, tag: str) -> None:
+        if not self._in_contacts_section:
+            return
+
+        if tag == "section":
+            self._contacts_section_depth -= 1
+            if self._contacts_section_depth <= 0:
+                self._in_contacts_section = False
+                self._contacts_section_depth = 0
+
+
+class TestContactSection(unittest.TestCase):
+    """Validate the contact section markup and styling requirements."""
+
+    def test_contact_section_structure(self) -> None:
+        """Contact section includes a grid plus inputs and copy buttons."""
+        content = INDEX_PATH.read_text(encoding="utf-8")
+        parser = ContactSectionParser()
+        parser.feed(content)
+
+        self.assertTrue(parser.has_contact_grid, "Expected a contact grid container.")
+        self.assertGreaterEqual(len(parser.readonly_inputs), 2)
+        self.assertEqual(
+            sorted(parser.readonly_inputs),
+            sorted(parser.copy_buttons),
+            "Each copy button should target a readonly input.",
+        )
+
+    def test_contact_styles(self) -> None:
+        """Contact styles use grid layout and pointer cursor for copy buttons."""
+        css = STYLE_PATH.read_text(encoding="utf-8")
+        grid_block = re.search(r"\.contact-grid\s*\{[^}]*\}", css, re.DOTALL)
+        self.assertIsNotNone(grid_block)
+        self.assertRegex(grid_block.group(0), r"display\s*:\s*grid")
+
+        button_block = re.search(r"\.copy-btn\s*\{[^}]*\}", css, re.DOTALL)
+        self.assertIsNotNone(button_block)
+        self.assertRegex(button_block.group(0), r"cursor\s*:\s*pointer")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a dedicated, copy-friendly contact area so visitors can quickly copy email and profile links.
- Improve usability and accessibility by exposing contact values as readonly inputs paired with explicit copy controls.
- Ensure the new UI remains maintainable by adding automated spec tests that assert markup and style expectations.

### Description
- Add a new `section` with `id="contacts"` in `index.html` containing a `.contact-grid` with three `.contact-card` entries (Email, LinkedIn, Portfolio) where each value is a `readonly` `input` paired with a `button` using `data-copy-target`.
- Add CSS in `style.css` to style `.contact-grid`, `.contact-card`, `.contact-copy`, inputs, and `.copy-btn` including hover/focus and copied states.
- Implement `initCopyButtons()` in `script.js` to wire copy buttons to the Clipboard API with a selection-based fallback and temporary visual feedback, and invoke it on `DOMContentLoaded`.
- Add `tests/test_contact_section.py` which parses `index.html` and `style.css` to validate the contact grid exists, inputs are readonly and targeted by copy buttons, and that CSS uses `display: grid` and pointer cursor for `.copy-btn`.

### Testing
- Ran the automated test suite with `python -m unittest discover -s tests` and all tests passed: 5 tests ran, OK.
- Tests exercise structural and CSS assertions for the contact section and copy controls and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3408cb808325afb52714fe4a13d3)